### PR TITLE
Feature – Add `getElementsByAttribute` Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Implemented methods:
 * getElementsByClassName
 * getElementsByTagName
 * getElementsByName
+* getElementsByAttribute
 
 ##### Node
 

--- a/lib/Dom.js
+++ b/lib/Dom.js
@@ -133,5 +133,10 @@ Dom.prototype.getElementsByName = function(name){
   return findByRegExp(this.rawHTML, selector);
 };
 
+Dom.prototype.getElementsByAttribute = function(attr, value){
+  var selector = new RegExp(attr + '=(\'|")' + value + '\\1');
+  return findByRegExp(this.rawHTML, selector);
+};
+
 
 module.exports = Dom;


### PR DESCRIPTION
This adds support for a `getElementsByAttribute` method.

It takes two arguments — attribute name and attribute value. Returns all `Node`s where this attribute with its respective value is found. 

https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Method/getElementsByAttribute