### PR TITLE
Solves #10

### DIFF
--- a/lib/Dom.js
+++ b/lib/Dom.js
@@ -119,7 +119,7 @@ Dom.prototype.getElementsByClassName = function (className) {
 };
 
 Dom.prototype.getElementsByTagName = function (tagName) {
-  var selector = new RegExp('^<'+tagName, 'i');
+  var selector = new RegExp('^<'+tagName+'[^a-z0-9]', 'i');
   return findByRegExp(this.rawHTML, selector);
 };
 


### PR DESCRIPTION
In general, when a tag is a prefix for another, looking for that tag will also return the other tag as well.
This update fixes #10.