### PR TITLE
feat: Support custom tags

### DIFF
--- a/src/lib/Dom.ts
+++ b/src/lib/Dom.ts
@@ -2,14 +2,14 @@ import { Node, NodeType } from './Node';
 import { NodeAttribute } from './NodeAttribute';
 
 const tagRegExp =
-  /(<\/?[a-z][a-z0-9]*(?::[a-z][a-z0-9]*)?\s*(?:\s+[a-z0-9-_]+(?:=(?:(?:'[\s\S]*?')|(?:"[\s\S]*?")))?)*\s*\/?>)|([^<]|<(?![a-z/]))*/gi;
+  /(<\/?(?:[a-z][a-z0-9]*:)?[a-z][a-z0-9-_.]*?[a-z0-9]*\s*(?:\s+[a-z0-9-_]+(?:=(?:(?:'[\s\S]*?')|(?:"[\s\S]*?")))?)*\s*\/?>)|([^<]|<(?![a-z/]))*/gi;
 const attrRegExp = /\s[a-z0-9-_]+\b(\s*=\s*('|")[\s\S]*?\2)?/gi;
 const splitAttrRegExp = /(\s[a-z0-9-_]+\b\s*)(?:=(\s*('|")[\s\S]*?\3))?/gi;
 const startTagExp = /^<[a-z]/;
 const selfCloseTagExp = /\/>$/;
 const closeTagExp = /^<\//;
 const textNodeExp = /^[^<]/;
-const nodeNameExp = /<\/?([a-z][a-z0-9]*)(?::([a-z][a-z0-9]*))?/i;
+const nodeNameExp = /<\/?((?:([a-z][a-z0-9]*):)?(?:[a-z][a-z0-9-_.]*[a-z0-9]))/i;
 const attributeQuotesExp = /^('|")|('|")$/g;
 const noClosingTagsExp = /^(?:area|base|br|col|command|embed|hr|img|input|link|meta|param|source)/i;
 
@@ -35,7 +35,7 @@ export class Dom {
   }
 
   getElementsByTagName(tagName: string) {
-    return this.find((node) => node.nodeName === tagName);
+    return this.find((node) => node.nodeName.toUpperCase() === tagName.toUpperCase());
   }
 
   getElementById(id: string): Node | null {

--- a/src/lib/Node.ts
+++ b/src/lib/Node.ts
@@ -106,7 +106,7 @@ export class Node {
   }
 
   getElementsByTagName(tagName: string) {
-    return searchElements(this, (elem) => elem.nodeName === tagName);
+    return searchElements(this, (elem) => elem.nodeName.toUpperCase() === tagName.toUpperCase());
   }
 
   getElementsByClassName(className: string) {

--- a/test/getElementsByTagName.test.ts
+++ b/test/getElementsByTagName.test.ts
@@ -38,4 +38,40 @@ describe('getElementsByTagName', () => {
       expect(spans).toHaveLength(5);
     });
   });
+
+  describe('custom tags', () => {
+    const html = `<div id="root" class="examples root">
+          <tip_link_head>
+            <tip-link>foo</tip-link>
+            <tip-link>foo</tip-link>
+          </tip_link_head>
+          <tip_link_head>
+            <tip:link>bar</tip:link>
+            <tip:link>bar</tip:link>
+          </tip_link_head>
+        </div>`;
+
+    it('Dom', () => {
+      const dom = parseFromString(html);
+      const tipsColon = dom.getElementsByTagName('tip:link');
+      const tipsHyphen = dom.getElementsByTagName('tip-link');
+      const tipsUnderline = dom.getElementsByTagName('tip_link_head');
+
+      expect(tipsColon).toHaveLength(2);
+      expect(tipsHyphen).toHaveLength(2);
+      expect(tipsUnderline).toHaveLength(2);
+    });
+
+    it('Node', () => {
+      const dom = parseFromString(html);
+      const root = dom.getElementById('root');
+      const tipsColon = root.getElementsByTagName('tip:link');
+      const tipsHyphen = root.getElementsByTagName('tip-link');
+      const tipsUnderline = root.getElementsByTagName('tip_link_head');
+
+      expect(tipsColon).toHaveLength(2);
+      expect(tipsHyphen).toHaveLength(2);
+      expect(tipsUnderline).toHaveLength(2);
+    });
+  });
 });

--- a/test/innerHTML.test.ts
+++ b/test/innerHTML.test.ts
@@ -6,6 +6,8 @@ it('innerHTML', () => {
           <span>
             <div class="broken">
               <div class="inner">1</div>
+              <n:div>with namespace</n:div>
+              <my-div>custom one</my-div>
               <br/>
             </div>
           </span>
@@ -15,6 +17,8 @@ it('innerHTML', () => {
           <span>
             <div class="broken">
               <div class="inner">1</div>
+              <n:div>with namespace</n:div>
+              <my-div>custom one</my-div>
               <br/>
             </div>
           </span>

--- a/test/outerHTML.test.ts
+++ b/test/outerHTML.test.ts
@@ -5,10 +5,12 @@ describe('outerHTML', () => {
     const html = `<div id="root">
         <div class="container">
           <span>
-            <div class="broken">
+            <div class="wrapper">
               <div class="inner">1</div>
               <br/>
               <input type="text" disabled/>
+              <n:div>with namespace</n:div>
+              <my-div>custom one</my-div>
             </div>
           </span>
         </div>


### PR DESCRIPTION
### Description
This PR adds support for custom tags with hyphens, colons, and dots.
The original standard for allowed symbols in custom tags is [here](https://html.spec.whatwg.org/#custom-elements-core-concepts)


Example:
```html
<div id="root" class="examples root">
  <tip_link_head>
    <tip-link>foo</tip-link>
    <tip-link>foo</tip-link>
  </tip_link_head>
  <tip_link_head>
    <tip:link>bar</tip:link>
    <tip:link>bar</tip:link>
  </tip_link_head>
</div>
```


### Addressed issue
https://github.com/ershov-konst/dom-parser/issues/5

### PS
Many thanks to @kstarzyk for the initial [PR](https://github.com/ershov-konst/dom-parser/pull/6)